### PR TITLE
增加黄区上报不同产品线的模型

### DIFF
--- a/src/plugins/statistics.ts
+++ b/src/plugins/statistics.ts
@@ -48,10 +48,8 @@ const constructData = (
     type: 'AIGC',
     user: username,
     userType: 'USER',
+    productLine: modelType in LinseerModelType ? productLineMap.get(modelType as LinseerModelType) : ""
   };
-  if (modelType in LinseerModelType) {
-    Object.assign(basicData, {productLine: productLineMap.get(modelType as LinseerModelType)})
-  }
 
   return [
     {
@@ -113,7 +111,9 @@ export default fastifyPlugin(async (fastify) => {
     version: string,
     username: string,
   ) => {
-    lastCursor = new Range(0, 0, 0, 0);
+    if (currentCursor.end.line == lastCursor.end.line) {
+      return;
+    }
     try {
       await axios
         .create({
@@ -142,7 +142,6 @@ export default fastifyPlugin(async (fastify) => {
     lastCursor = currentCursor;
     currentCursor = cursor;
   };
-  
 });
 
 declare module 'fastify' {

--- a/src/plugins/statistics.ts
+++ b/src/plugins/statistics.ts
@@ -18,6 +18,13 @@ const secondClassMap = new Map<HuggingFaceModelType | LinseerModelType, string>(
     [LinseerModelType.Linseer_CClsw, 'LS13B'],
   ],
 );
+const productLineMap = new Map<LinseerModelType, string >(
+  [
+    [LinseerModelType.Linseer, "H3C 通用"],
+    [LinseerModelType.Linseer_CClsw, "交换机产品线"],
+    [LinseerModelType.Linseer_SR88Driver, ""], //高端路由模型还未推出，产品线字段暂时返回空，后续更新删除该注释
+  ]
+);
 
 const constructData = (
   completion: string,
@@ -42,6 +49,9 @@ const constructData = (
     user: username,
     userType: 'USER',
   };
+  if (modelType as LinseerModelType) {
+    Object.assign(basicData, {productline: productLineMap.get(modelType)})
+  }
 
   return [
     {

--- a/src/plugins/statistics.ts
+++ b/src/plugins/statistics.ts
@@ -49,8 +49,8 @@ const constructData = (
     user: username,
     userType: 'USER',
   };
-  if (modelType as LinseerModelType) {
-    Object.assign(basicData, {productline: productLineMap.get(modelType)})
+  if (modelType in LinseerModelType) {
+    Object.assign(basicData, {productLine: productLineMap.get(modelType as LinseerModelType)})
   }
 
   return [
@@ -113,9 +113,7 @@ export default fastifyPlugin(async (fastify) => {
     version: string,
     username: string,
   ) => {
-    if (currentCursor.end.line == lastCursor.end.line) {
-      return;
-    }
+    lastCursor = new Range(0, 0, 0, 0);
     try {
       await axios
         .create({
@@ -144,6 +142,7 @@ export default fastifyPlugin(async (fastify) => {
     lastCursor = currentCursor;
     currentCursor = cursor;
   };
+  
 });
 
 declare module 'fastify' {


### PR DESCRIPTION
接口请求里加个参数productLine：
model为linseer-code-13b和linseer-code-34b时，productLine为 “H3C通用”；
model为linseer-code-13b-cclsw时，productLine为”交换机产品线”
这个参数不影响调用，影响我们这边的一些数据统计，麻烦添加一下 多谢。